### PR TITLE
Make depends on autopilot-qt4 optional

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,7 @@ Vcs-Browser: https://bazaar.launchpad.net/~autopilot/autopilot-qt/trunk/files
 Package: libautopilot-qt
 Section: libs
 Architecture: any
-Depends: autopilot-qt4,
-         autopilot-qt5,
+Depends: autopilot-qt5 | autopilot-qt4,
          qttestability-autopilot,
          ${misc:Depends},
          ${shlibs:Depends},


### PR DESCRIPTION
Make the dependency on autopilot-qt4 optional, as with newer versions of Qt 5 in Debian packaging, there are conflicts created with qdbus dependency stack.